### PR TITLE
Added check for the correct content type in addition to the response status code.

### DIFF
--- a/ca-store-generator.js
+++ b/ca-store-generator.js
@@ -200,7 +200,7 @@ function run(filename) {
 
     if (!fs.existsSync(outputPemsDir)) {
       fs.mkdirSync(outputPemsDir);
-    } 
+    }
 
     console.info("Loading latest certificates from " + CERTDB_URL);
     request.get(CERTDB_URL, function (error, response, body) {
@@ -214,6 +214,12 @@ function run(filename) {
       if (response.statusCode !== 200) {
         console.error("Fetching failed with status code %s", response.statusCode);
         reject({ code: 2, error: "Fetching failed with status code " + response.statusCode });
+        return;
+      }
+
+      if (response.headers['content-type'] !== 'text/plain') {
+        console.error("Fetching failed with incorrect content type %s", response.headers['content-type']);
+        reject({ code: 2, error: "Fetching failed with incorrect content type " + response.headers['content-type'] });
         return;
       }
 


### PR DESCRIPTION
I recently experienced an issue where the CA functionality was broken because Mozilla has a maintenance page up for the CA link in the code (https://mxr.mozilla.org/nss/source/lib/ckfw/builtins/certdata.txt?raw=1) and unfortunately that maintenance page returns a 200 status. That means the HTML page was being downloaded as the CA, which didn't exactly work super well.

My change adds an additional check for the content type to be text/plain in addition to the status code check.